### PR TITLE
set status.observedGeneration after reconcile

### DIFF
--- a/pkg/controller/dnsrecord/actuator.go
+++ b/pkg/controller/dnsrecord/actuator.go
@@ -90,6 +90,7 @@ func (a *actuator) Reconcile(ctx context.Context, dns *extensionsv1alpha1.DNSRec
 	// Update resource status
 	patch := client.MergeFrom(dns.DeepCopy())
 	dns.Status.Zone = &managedZone
+	dns.Status.ObservedGeneration = dns.Generation
 	return a.Client().Status().Patch(ctx, dns, patch)
 }
 


### PR DESCRIPTION
Hey!

I've been testing your extension for a few days, after a cluster reconfiguration, gardener complained about the `DNSRecords` not being reconciled. However, they were successfully updated.

After manually updating `status.observedGeneration` to the current resource generation, the gardener reconciliation continued.

I'm not sure if that's supposed to be done by the gardener extension framework. I didn't see anything after taking a quick look at the provided methods.

I guess patching the status in the `Reconcile` method should work fine as well...

The expected behaviour regarding `observedGeneration` is explained here:
https://github.com/gardener/gardener/blob/master/docs/proposals/01-extensibility.md#custom-resource-definitions